### PR TITLE
Refactor jmp condition

### DIFF
--- a/b9jit.cpp
+++ b/b9jit.cpp
@@ -475,24 +475,14 @@ bool B9Method::generateILForBytecode(
     case JMP:
         handle_bc_jmp(builder, bytecodeBuilderTable, program,bytecodeIndex);
         break;
-    case JMP_EQ:
-        handle_bc_jmp_eq(builder, bytecodeBuilderTable, program,bytecodeIndex, nextBytecodeBuilder);
-        break;
+    case JMP_EQ: 
     case JMP_NEQ:
-        handle_bc_jmp_neq(builder, bytecodeBuilderTable, program,bytecodeIndex, nextBytecodeBuilder);
-        break;
     case JMP_LT:
-        handle_bc_jmp_lt(builder, bytecodeBuilderTable, program,bytecodeIndex, nextBytecodeBuilder);
-        break;
     case JMP_LE:
-        handle_bc_jmp_le(builder, bytecodeBuilderTable, program,bytecodeIndex, nextBytecodeBuilder);
-        break;
     case JMP_GT:
-        handle_bc_jmp_gt(builder, bytecodeBuilderTable, program,bytecodeIndex, nextBytecodeBuilder);
-        break;
     case JMP_GE:
-        handle_bc_jmp_ge(builder, bytecodeBuilderTable, program,bytecodeIndex, nextBytecodeBuilder);
-        break;
+        handle_bc_jmp_condition(builder, bytecodeBuilderTable, program,bytecodeIndex, nextBytecodeBuilder);
+        break; 
     case SUB:
         handle_bc_sub(builder, nextBytecodeBuilder);
         break;
@@ -626,112 +616,42 @@ void B9Method::handle_bc_jmp(TR::BytecodeBuilder* builder, TR::BytecodeBuilder**
     builder->Goto(destBuilder);
 }
 
-void B9Method::handle_bc_jmp_eq(TR::BytecodeBuilder* builder,
+void B9Method::handle_bc_jmp_condition(TR::BytecodeBuilder* builder,
     TR::BytecodeBuilder** bytecodeBuilderTable,
-    Instruction *program,
+    Instruction *program,  
     long bytecodeIndex,
     TR::BytecodeBuilder* nextBuilder)
 {
     Instruction instruction = program[bytecodeIndex];
+    ByteCode bytecode = getByteCodeFromInstruction(instruction);
     StackElement delta = getParameterFromInstruction(instruction) + 1;
     int next_bc_index = bytecodeIndex + delta;
     TR::BytecodeBuilder* jumpTo = bytecodeBuilderTable[next_bc_index];
 
     TR::IlValue* right = pop(builder);
     TR::IlValue* left = pop(builder);
-
-    builder->IfCmpEqual(jumpTo, left, right);
-    builder->AddFallThroughBuilder(nextBuilder);
-}
-
-void B9Method::handle_bc_jmp_neq(TR::BytecodeBuilder* builder,
-    TR::BytecodeBuilder** bytecodeBuilderTable,
-    Instruction *program,
-    long bytecodeIndex,
-    TR::BytecodeBuilder* nextBuilder)
-{
-    Instruction instruction = program[bytecodeIndex];
-    StackElement delta = getParameterFromInstruction(instruction) + 1;
-    int next_bc_index = bytecodeIndex + delta;
-    TR::BytecodeBuilder* jumpTo = bytecodeBuilderTable[next_bc_index];
-
-    TR::IlValue* right = pop(builder);
-    TR::IlValue* left = pop(builder);
-
-    builder->IfCmpNotEqual(jumpTo, left, right);
-    builder->AddFallThroughBuilder(nextBuilder);
-}
-
-void B9Method::handle_bc_jmp_lt(TR::BytecodeBuilder* builder,
-    TR::BytecodeBuilder** bytecodeBuilderTable,
-    Instruction *program,
-    long bytecodeIndex,
-    TR::BytecodeBuilder* nextBuilder)
-{
-    Instruction instruction = program[bytecodeIndex];
-    StackElement delta = getParameterFromInstruction(instruction) + 1;
-    int next_bc_index = bytecodeIndex + delta;
-    TR::BytecodeBuilder* jumpTo = bytecodeBuilderTable[next_bc_index];
-
-    TR::IlValue* right = pop(builder);
-    TR::IlValue* left = pop(builder);
-
-    builder->IfCmpLessThan(jumpTo, left, right);
-    builder->AddFallThroughBuilder(nextBuilder);
-}
-void B9Method::handle_bc_jmp_le(TR::BytecodeBuilder* builder,
-    TR::BytecodeBuilder** bytecodeBuilderTable,
-    Instruction *program,
-    long bytecodeIndex,
-    TR::BytecodeBuilder* nextBuilder)
-{
-    Instruction instruction = program[bytecodeIndex];
-
-    StackElement delta = getParameterFromInstruction(instruction) + 1;
-
-    TR::IlValue* right = pop(builder);
-    TR::IlValue* left = pop(builder);
-
-    int next_bc_index = bytecodeIndex + delta;
-    TR::BytecodeBuilder* jumpTo = bytecodeBuilderTable[next_bc_index];
-    left = builder->Sub(left, builder->ConstInt64(1));
-    builder->IfCmpGreaterThan(jumpTo, right, left); //swap and do a greaterthan
-    builder->AddFallThroughBuilder(nextBuilder);
-}
-void B9Method::handle_bc_jmp_gt(TR::BytecodeBuilder* builder,
-    TR::BytecodeBuilder** bytecodeBuilderTable,
-    Instruction *program,
-    long bytecodeIndex,
-    TR::BytecodeBuilder* nextBuilder)
-{
-    Instruction instruction = program[bytecodeIndex];
-    StackElement delta = getParameterFromInstruction(instruction) + 1;
-    int next_bc_index = bytecodeIndex + delta;
-    TR::BytecodeBuilder* jumpTo = bytecodeBuilderTable[next_bc_index];
-
-    TR::IlValue* right = pop(builder);
-    TR::IlValue* left = pop(builder);
-
-    builder->IfCmpGreaterThan(jumpTo, left, right);
-    builder->AddFallThroughBuilder(nextBuilder);
-}
-void B9Method::handle_bc_jmp_ge(TR::BytecodeBuilder* builder,
-    TR::BytecodeBuilder** bytecodeBuilderTable,
-    Instruction *program,
-    long bytecodeIndex,
-    TR::BytecodeBuilder* nextBuilder)
-{
-    Instruction instruction = program[bytecodeIndex];
-    StackElement delta = getParameterFromInstruction(instruction) + 1;
-    int next_bc_index = bytecodeIndex + delta;
-    TR::BytecodeBuilder* jumpTo = bytecodeBuilderTable[next_bc_index];
-
-    TR::IlValue* right = pop(builder);
-    TR::IlValue* left = pop(builder);
-
-    // if (left >= right) jump is converted to if (left > (right-1) jump  
-    right = builder->Sub(right, builder->ConstInt64(1));
-    builder->IfCmpGreaterThan(jumpTo, left, right); 
+    switch (bytecode) {
+    case JMP_EQ:
+        builder->IfCmpEqual(jumpTo, left, right);
+        break;
+    case JMP_NEQ:
+        builder->IfCmpNotEqual(jumpTo, left, right);
+        break;
+    case JMP_LT:
+        builder->IfCmpLessThan(jumpTo, left, right);
+        break;
+    case JMP_LE:
+        builder->IfCmpLessOrEqual(jumpTo, left, right);
+        break;
+    case JMP_GT:
+        builder->IfCmpGreaterThan(jumpTo, left, right);
+        break;
+    case JMP_GE:
+        builder->IfCmpGreaterOrEqual(jumpTo, left, right);
+        break;
+    default:
+        break;
+    }
     builder->AddFallThroughBuilder(nextBuilder);
 }
 

--- a/b9jit.hpp
+++ b/b9jit.hpp
@@ -89,18 +89,9 @@ private:
     handle_bc_call(TR::BytecodeBuilder *builder, TR::BytecodeBuilder *nextBuilder);
     void
     handle_bc_jmp(TR::BytecodeBuilder *builder, TR::BytecodeBuilder **bytecodeBuilderTable, Instruction *program, long bytecodeIndex);
+    
     void
-    handle_bc_jmp_eq(TR::BytecodeBuilder *builder, TR::BytecodeBuilder **bytecodeBuilderTable,  Instruction *program, long bytecodeIndex, TR::BytecodeBuilder *nextBuilder);
-    void
-    handle_bc_jmp_neq(TR::BytecodeBuilder *builder, TR::BytecodeBuilder **bytecodeBuilderTable, Instruction *program, long bytecodeIndex, TR::BytecodeBuilder *nextBuilder);
-    void
-    handle_bc_jmp_lt(TR::BytecodeBuilder *builder, TR::BytecodeBuilder **bytecodeBuilderTable, Instruction *program, long bytecodeIndex, TR::BytecodeBuilder *nextBuilder);
-    void
-    handle_bc_jmp_le(TR::BytecodeBuilder *builder, TR::BytecodeBuilder **bytecodeBuilderTable, Instruction *program, long bytecodeIndex, TR::BytecodeBuilder *nextBuilder);
-    void
-    handle_bc_jmp_gt(TR::BytecodeBuilder *builder, TR::BytecodeBuilder **bytecodeBuilderTable, Instruction *program, long bytecodeIndex, TR::BytecodeBuilder *nextBuilder);
-    void
-    handle_bc_jmp_ge(TR::BytecodeBuilder *builder, TR::BytecodeBuilder **bytecodeBuilderTable, Instruction *program, long bytecodeIndex, TR::BytecodeBuilder *nextBuilder);
+    handle_bc_jmp_condition(TR::BytecodeBuilder *builder, TR::BytecodeBuilder **bytecodeBuilderTable,  Instruction *program, long bytecodeIndex, TR::BytecodeBuilder *nextBuilder);
 
 };
 

--- a/b9test.cpp
+++ b/b9test.cpp
@@ -91,6 +91,8 @@ run_test(ExecutionContext *context, const char *testName)
             printf("Mode %s, Test \"%s\": success, returned %X\n", mode, testName, result);
         }
     }
+ 
+
     return result;
 }
 
@@ -135,6 +137,9 @@ main(int argc, char *argv[])
     test_validateFibResult(context);
 
     int count;
+    int passed = 0;
+    int failed = 0;
+
     for (count = 0; count < 2; count++) {
 
         // run all tests in the program which start with test_
@@ -142,13 +147,20 @@ main(int argc, char *argv[])
         int functionIndex = 0;
         while (functions[functionIndex].name != NO_MORE_FUNCTIONS) {
             if (strncmp("test_", functions[functionIndex].name, 5) == 0) {
-                run_test(context, functions[functionIndex].name);
+                if (run_test(context, functions[functionIndex].name)) { 
+                    passed++;
+                } else { 
+                    failed++;
+                }
             }
             functionIndex++;
         }
         generateAllCode(context); // first time interpreted, second time JIT
     }
 
+    double percent = (passed*100.0/(passed+failed));
+
+    printf ("B9 Tests  %4.1f %% Passed. Total tests %d. Passed (%d) Failed (%d) \n", percent, passed+failed, passed, failed);
     if (result) {
         return EXIT_SUCCESS;
     } else {


### PR DESCRIPTION
Refactor jmp_conditional to one function and update the tests to give a summary.

The code for jmp_xx was common except the specific IfCmp test. Refactored to single function so we can more easily change the code to account for frequency on branch taken and not-taken and ensure the fast path is a fall through case by inverting the test.
