### PR TITLE
tolerate configure file

### DIFF
--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ $(programs): $(LIB)
 	$(CXX) -o $@ -lm $^ -ldl $(cflags) $(CFLAGS) $(LINK)
 
 $(LIB): $(omr_srcdir)
-	(cd $(omr_srcdir)/; ./configure)
+	(cd $(omr_srcdir)/; sh ./configure)
 	(cd $(omr_srcdir)/jitbuilder; make)
 
 program: b9


### PR DESCRIPTION
If the configure file is not executable the makefile cannot run it, so changed the command to be passed to sh so it doesn't need to be executable.