### PR TITLE
Properly calculate the register count of a function

### DIFF
--- a/b9/core.cpp
+++ b/b9/core.cpp
@@ -210,13 +210,11 @@ StackElement ExecutionContext::interpret(const FunctionSpec *function) {
   }
 #endif  // defined(B9JIT)
 
-  const auto tmps = 10;
-
   // printf("Prog Arg Count %d, tmp count %d\n", nargs, tmps);
 
   const Instruction *instructionPointer = function->address;
   StackElement *args = stackPointer_ - function->nargs;
-  stackPointer_ += 10;  // TODO: tmp count!!!!VERY BAD!!
+  stackPointer_ += function->nregs;
 
   while (*instructionPointer != NO_MORE_BYTECODES) {
     // b9PrintStack(context);

--- a/include/b9/module.hpp
+++ b/include/b9/module.hpp
@@ -8,7 +8,6 @@
 namespace b9 {
 
 /// Function specification. Metadata about a function.
-/// TODO: Indicate tmp space required.
 struct FunctionSpec {
   FunctionSpec(const std::string& name, const Instruction* address,
                std::uint32_t nargs = 0, std::uint32_t nregs = 0,
@@ -27,7 +26,6 @@ struct FunctionSpec {
 };
 
 /// An interpreter module.
-/// TODO: Map names->Functions
 struct Module {
   std::vector<FunctionSpec> functions;
   std::vector<PrimitiveFunction*> primitives;


### PR DESCRIPTION
The registers are indexable operand stack slots int the VM. Right now,
the registers correspond exactly to the local variables of a function.

This patch updates the function handler to store the number of registers
required into the function declaration. This happens at the end of the
function handler. Then, we defers the generation of the function table
entries later, after the functions have been handled.

Signed-off-by: Robert Young <rwy0717@gmail.com>