### PR TITLE
Move call to findFunction for -loop option

### DIFF
--- a/b9run/main.cpp
+++ b/b9run/main.cpp
@@ -112,8 +112,9 @@ static void run(const RunConfig& cfg) {
 
   vm.load(module);
   
+  size_t functionIndex = module->findFunction(cfg.mainFunction);
   for (std::size_t i = 0; i < cfg.loopCount; i++) {
-    vm.run(cfg.mainFunction);
+    vm.run(functionIndex);
   }
 }
 


### PR DESCRIPTION
Move call to outside for loop in main.cpp. Call run with function
index rather than function name to avoid looping through the function
table on each iteration.

Signed-off-by: Arianne Butler <arianne.butler@ibm.com>