### PR TITLE
Support loading modules from relative paths

### DIFF
--- a/b9run/CMakeLists.txt
+++ b/b9run/CMakeLists.txt
@@ -3,3 +3,9 @@ add_executable(b9run
 )
 
 target_link_libraries(b9run b9)
+
+set_target_properties(b9run
+	PROPERTIES
+		INSTALL_RPATH .
+)
+

--- a/b9run/CMakeLists.txt
+++ b/b9run/CMakeLists.txt
@@ -4,8 +4,7 @@ add_executable(b9run
 
 target_link_libraries(b9run b9)
 
-set_target_properties(b9run
-	PROPERTIES
-		INSTALL_RPATH .
+add_custom_command(TARGET b9run POST_BUILD
+	COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "./" $<TARGET_FILE:b9run>
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,4 +22,9 @@ add_test(
 	COMMAND env B9_TEST_MODULE=$<TARGET_FILE:interpreter_test> $<TARGET_FILE:b9test>
 )
 
+add_test(
+	NAME run_hello_relative
+	COMMAND b9run $<TARGET_FILE_NAME:hello>
+	WORKING_DIRECTORY $<TARGET_FILE_DIR:hello>
+)
 


### PR DESCRIPTION
Add the working directory to the RPATH. Add a test to ensure that a relative path will actually work.