### PR TITLE
Run formatter

### DIFF
--- a/b9/core.cpp
+++ b/b9/core.cpp
@@ -118,7 +118,6 @@ void ExecutionContext::intSub() {
 /// ExecutionContext
 
 bool VirtualMachine::initialize() {
-
   if (cfg_.jitEnabled) {
     if (!initializeJit()) {
       return false;
@@ -131,7 +130,7 @@ bool VirtualMachine::initialize() {
 
 bool VirtualMachine::shutdown() {
   if (cfg_.jitEnabled) {
-    delete(compiler_);
+    delete (compiler_);
     shutdownJit();
   }
   return true;
@@ -306,7 +305,7 @@ void *VirtualMachine::getJitAddress(std::size_t functionIndex) {
   return compiledFunctions_[functionIndex];
 }
 
-void VirtualMachine::setJitAddress(std::size_t functionIndex, void* value) {
+void VirtualMachine::setJitAddress(std::size_t functionIndex, void *value) {
   compiledFunctions_[functionIndex] = value;
 }
 
@@ -352,7 +351,7 @@ void ExecutionContext::reset() {
   programCounter_ = 0;
 }
 
-StackElement VirtualMachine::run(const std::string& name) {
+StackElement VirtualMachine::run(const std::string &name) {
   return run(module_->findFunction(name));
 }
 

--- a/b9/include/b9.hpp
+++ b/b9/include/b9.hpp
@@ -75,10 +75,10 @@ class ExecutionContext {
   // private
   Stack stackFields = {stack_, stack_};
 
-private:
+ private:
   StackElement stack_[1000];
-  StackElement* &stackBase_ = stackFields.stackBase;
-  StackElement* &stackPointer_ = stackFields.stackPointer;
+  StackElement *&stackBase_ = stackFields.stackBase;
+  StackElement *&stackPointer_ = stackFields.stackPointer;
   Instruction *programCounter_ = 0;
   StackElement *stackEnd_ = &stack_[1000];
   VirtualMachine *virtualMachine_;
@@ -95,14 +95,14 @@ class VirtualMachine {
   /// Load a module into the VM.
   void load(std::shared_ptr<const Module> module);
   StackElement run(const std::size_t index);
-  StackElement run(const std::string& name);
+  StackElement run(const std::string &name);
 
   // private
   const FunctionSpec *getFunction(std::size_t index);
   PrimitiveFunction *getPrimitive(std::size_t index);
 
   void *getJitAddress(std::size_t functionIndex);
-  void setJitAddress(std::size_t functionIndex, void* value);
+  void setJitAddress(std::size_t functionIndex, void *value);
 
   std::size_t getFunctionCount();
   void generateCode(int32_t functionIndex);
@@ -119,6 +119,6 @@ class VirtualMachine {
   std::vector<void *> compiledFunctions_;
 };
 
-} // namespace b9
+}  // namespace b9
 
-#endif // B9_HPP_
+#endif  // B9_HPP_

--- a/b9/include/b9/core.hpp
+++ b/b9/include/b9/core.hpp
@@ -44,7 +44,8 @@ void bc_primitive(VirtualMachine *context, Parameter value);
 // typedef StackElement (*Interpret) (ExecutionContext* context, Instruction*
 // program);
 
-typedef StackElement (*Interpret) (ExecutionContext* context, Instruction* program);
+typedef StackElement (*Interpret)(ExecutionContext *context,
+                                  Instruction *program);
 
 // define C callable Interpret API for each arg call
 // if args are passed to the function, they are not passed
@@ -79,14 +80,13 @@ Instruction *getFunctionAddress(ExecutionContext *context,
 StackElement timeFunction(VirtualMachine *virtualMachine, Instruction *function,
                           int loopCount, long *runningTime);
 
-StackElement
-interpret_0(ExecutionContext *context, Instruction *program);
-StackElement
-interpret_1(ExecutionContext *context, Instruction *program, StackElement p1);
-StackElement
-interpret_2(ExecutionContext *context, Instruction *program, StackElement p1, StackElement p2);
-StackElement
-interpret_3(ExecutionContext *context, Instruction *program, StackElement p1, StackElement p2, StackElement p3 );
+StackElement interpret_0(ExecutionContext *context, Instruction *program);
+StackElement interpret_1(ExecutionContext *context, Instruction *program,
+                         StackElement p1);
+StackElement interpret_2(ExecutionContext *context, Instruction *program,
+                         StackElement p1, StackElement p2);
+StackElement interpret_3(ExecutionContext *context, Instruction *program,
+                         StackElement p1, StackElement p2, StackElement p3);
 
 StackElement interpret_0(ExecutionContext *context, Instruction *program);
 StackElement interpret_1(ExecutionContext *context, Instruction *program,

--- a/b9/include/b9/jit.hpp
+++ b/b9/include/b9/jit.hpp
@@ -17,15 +17,17 @@ class Stack;
 
 class MethodBuilder : public TR::MethodBuilder {
  public:
-  MethodBuilder(VirtualMachine *virtualMachine, TR::TypeDictionary *types, const JitConfig & config, const FunctionSpec & functionSpec, Stack *stack);
+  MethodBuilder(VirtualMachine *virtualMachine, TR::TypeDictionary *types,
+                const JitConfig &config, const FunctionSpec &functionSpec,
+                Stack *stack);
 
   virtual bool buildIL();
 
  private:
   VirtualMachine *virtualMachine_;
   TR::TypeDictionary *types_;
-  const JitConfig & config_;
-  const FunctionSpec & functionSpec_;
+  const JitConfig &config_;
+  const FunctionSpec &functionSpec_;
   Stack *stack_;
   int32_t topLevelProgramIndex;
   int32_t maxInlineDepth;
@@ -47,8 +49,7 @@ class MethodBuilder : public TR::MethodBuilder {
                                 ByteCode bytecode, int64_t bytecodeIndex);
   bool generateILForBytecode(
       std::vector<TR::BytecodeBuilder *> bytecodeBuilderTable,
-      const Instruction *program,
-      ByteCode bytecode, long bytecodeIndex,
+      const Instruction *program, ByteCode bytecode, long bytecodeIndex,
       TR::BytecodeBuilder *jumpToBuilderForInlinedReturn);
 
   bool inlineProgramIntoBuilder(
@@ -110,14 +111,14 @@ class MethodBuilder : public TR::MethodBuilder {
 };
 
 class Compiler {
-public:
-  Compiler (VirtualMachine *virtualMachine, const JitConfig & jitConfig);
-  uint8_t *generateCode(const FunctionSpec & functionSpec);
+ public:
+  Compiler(VirtualMachine *virtualMachine, const JitConfig &jitConfig);
+  uint8_t *generateCode(const FunctionSpec &functionSpec);
 
-private:
+ private:
   TR::TypeDictionary types_;
   VirtualMachine *virtualMachine_;
-  const JitConfig & jitConfig_;
+  const JitConfig &jitConfig_;
 };
 
 }  // namespace b9

--- a/b9/include/b9/module.hpp
+++ b/b9/include/b9/module.hpp
@@ -3,8 +3,8 @@
 
 #include <b9/core.hpp>
 #include <cstdint>
-#include <vector>
 #include <stdexcept>
+#include <vector>
 
 namespace b9 {
 
@@ -12,10 +12,7 @@ namespace b9 {
 struct FunctionSpec {
   FunctionSpec(const std::string& name, const Instruction* address,
                std::uint32_t nargs = 0, std::uint32_t nregs = 0)
-      : address{address},
-        nargs{nargs},
-        nregs{nregs},
-        name{name} {}
+      : address{address}, nargs{nargs}, nregs{nregs}, name{name} {}
 
   const Instruction* address;
   std::uint32_t nargs;

--- a/b9run/main.cpp
+++ b/b9run/main.cpp
@@ -111,19 +111,20 @@ static void run(const RunConfig& cfg) {
   }
 
   vm.load(module);
-  
+
   size_t functionIndex = module->findFunction(cfg.mainFunction);
-  
+
   if (cfg.loopCount == 1) {
     b9::StackElement returnVal = vm.run(functionIndex);
     std::cout << cfg.mainFunction << " returned: " << returnVal << std::endl;
-  }
-  else {
+  } else {
     b9::StackElement returnVal;
-    std::cout << "Running " << cfg.mainFunction << " " << cfg.loopCount << " times:" << std::endl;
+    std::cout << "Running " << cfg.mainFunction << " " << cfg.loopCount
+              << " times:" << std::endl;
     for (std::size_t i = 1; i <= cfg.loopCount; i++) {
       returnVal = vm.run(functionIndex);
-      std::cout << "Return value of iteration " << i << ": " << returnVal << std::endl;
+      std::cout << "Return value of iteration " << i << ": " << returnVal
+                << std::endl;
     }
   }
 }

--- a/test/b9test.cpp
+++ b/test/b9test.cpp
@@ -11,18 +11,16 @@ namespace b9 {
 namespace test {
 
 class InterpreterTestEnvironment : public ::testing::Environment {
-  public:
-    static const char* moduleName;
+ public:
+  static const char* moduleName;
 
-    virtual void SetUp() {
-      moduleName = getenv("B9_TEST_MODULE");
-    }
+  virtual void SetUp() { moduleName = getenv("B9_TEST_MODULE"); }
 };
 
 const char* InterpreterTestEnvironment::moduleName{nullptr};
 
 class InterpreterTest : public ::testing::TestWithParam<const char*> {
-public:
+ public:
   static std::shared_ptr<Module> module_;
   VirtualMachine virtualMachine_{{}};
 
@@ -31,16 +29,14 @@ public:
     module_ = loader.loadModule(InterpreterTestEnvironment::moduleName);
   }
 
-  virtual void SetUp() {
-    virtualMachine_.load(module_);
-  }
+  virtual void SetUp() { virtualMachine_.load(module_); }
 };
 
 std::shared_ptr<Module> InterpreterTest::module_{nullptr};
 
-TEST_P(InterpreterTest, run) {
-  EXPECT_TRUE(virtualMachine_.run(GetParam()));
-}
+TEST_P(InterpreterTest, run) { EXPECT_TRUE(virtualMachine_.run(GetParam())); }
+
+// clang-format off
 
 INSTANTIATE_TEST_CASE_P(InterpreterTestSuite, InterpreterTest,
   ::testing::Values(
@@ -68,12 +64,13 @@ INSTANTIATE_TEST_CASE_P(InterpreterTestSuite, InterpreterTest,
     "test_while"
 ));
 
-} // namespace test
-} // namespace b9
+// clang-format on
+
+}  // namespace test
+}  // namespace b9
 
 extern "C" int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   AddGlobalTestEnvironment(new b9::test::InterpreterTestEnvironment{});
   return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
Now that we've reenabled the jit, I thought it might make sense to re-run the formatter. I disabled formatting around the list of tests in b9test.cpp, since google's style doesn't binpack the arguments ever, and the huge list of strings was hideous.