### PR TITLE
Break add_b9_program into stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,4 @@ script:
     - mkdir build && cd build
     - cmake ..
     - make -j8
-    - make programs
     - ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,33 +34,36 @@ set(OMR_GC         ON CACHE INTERNAL "We don't use the GC in b9 (yet)")
 set(OMR_FVTEST     OFF CACHE INTERNAL "Disable OMR's internal test suite, it's incompatible with b9")
 set(OMR_WARNINGS_AS_ERRORS OFF CACHE INTERNAL "OMR doesn't compile cleanly on my laptop :p")
 
-# B9 basic configuration library
-
-add_library(b9interface INTERFACE)
-
-add_custom_target(programs)
-
-function(add_b9_program program)
+# Compile a b9-js *.src to C++
+function(add_b9_src src)
 	add_custom_command(
 		OUTPUT
-			"${program}.cpp"
+			"${src}.cpp"
 		COMMAND
 			${NODE_EXECUTABLE} "${CMAKE_SOURCE_DIR}/js_compiler/compile.js"
-			"${CMAKE_CURRENT_SOURCE_DIR}/${program}.src"
-			>"${program}.cpp"
+			"${CMAKE_CURRENT_SOURCE_DIR}/${src}.src"
+			>"${src}.cpp"
 		DEPENDS
 			"${CMAKE_SOURCE_DIR}/js_compiler/compile.js"
-			"${CMAKE_CURRENT_SOURCE_DIR}/${program}.src"
+			"${CMAKE_CURRENT_SOURCE_DIR}/${src}.src"
 	)
+endfunction(add_b9_src)
 
-	add_library("${program}" SHARED "${program}.cpp")
-	target_link_libraries("${program}" b9)
-	add_dependencies(programs "${program}")
+# Compile a b9-js *.src file to a module DLL
+function(add_b9_module module)
+	add_b9_src(${module})
+	add_library(${module} SHARED "${module}.cpp")
+	target_link_libraries("${module}" b9)
+endfunction(add_b9_module)
+
+# Add a b9 test program written in b9-js
+function(add_b9_test test)
+	add_b9_module("${test}")
 	add_test(
-		NAME "run_${program}"
-		COMMAND b9run $<TARGET_FILE:${program}>
+		NAME "run_${test}"
+		COMMAND b9run $<TARGET_FILE:${test}>
 	)
-endfunction(add_b9_program)
+endfunction(add_b9_test)
 
 # Subdirectories
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 
 # Test Programs
 
-add_b9_program(fib)
-add_b9_program(hello)
-add_b9_program(interpreter_test)
-
+add_b9_test(fib)
+add_b9_test(hello)
 
 # b9 test - The native test
+
+add_b9_module(interpreter_test)
 
 add_executable(b9test
 	b9test.cpp
@@ -21,5 +21,4 @@ add_test(
 	NAME run_b9test
 	COMMAND env B9_TEST_MODULE=$<TARGET_FILE:interpreter_test> $<TARGET_FILE:b9test>
 )
-
 


### PR DESCRIPTION
This lets us add the test_interpreter module without also running it as a test.
This patch also deletes the custom target programs, since it's not useful.

While I'm here, delete the embty b9interface library, since it's not used by the
programs any more. It's flags are inherited directly from the b9 library.

Signed-off-by: Robert Young <rwy0717@gmail.com>