### PR TITLE
Output b9run into bin/

### DIFF
--- a/b9run/CMakeLists.txt
+++ b/b9run/CMakeLists.txt
@@ -2,4 +2,9 @@ add_executable(b9run
 	main.cpp
 )
 
+set_target_properties(b9run
+	PROPERTIES
+		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
 target_link_libraries(b9run b9)


### PR DESCRIPTION
This should be less confusing for users. People will write bin/b9run,
not b9run/b9run.

Signed-off-by: Robert Young <rwy0717@gmail.com>