### PR TITLE
Output correct number of arguments on busted nodejs versions

### DIFF
--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -234,7 +234,7 @@ function CodeGen(f) {
         this.outputLines.push({"computeText": function () {
             var function_table = 'static const DlFunctionEntry b9_functions[] = {\n'
             for (name in functions) {
-                const f = functions[name];
+                var f = functions[name];
                 function_table += '  { "' + name + '", ' + name + ', ' + f.nargs + ', ' + f.nregs + '}, // ' + f + "\n";
             }
             function_table += '};\n'


### PR DESCRIPTION
Variable f was declared as const, which caused it to be set
once in the first iteration of the loop. In subsequent
iterations it was not being set again. This caused us to
use the first function decl in every iteration.