### PR TITLE
Refactor bytecode ordering

### DIFF
--- a/b9/include/b9/bytecodes.hpp
+++ b/b9/include/b9/bytecodes.hpp
@@ -10,24 +10,25 @@ namespace b9 {
 using RawByteCode = std::uint8_t;
 
 enum class ByteCode : RawByteCode {
+
   // Generic ByteCodes
 
   // A special uninterpreted ByteCode placed the end of a
   // ByteCode array.
   END_SECTION = 0x0,
 
-  // Drop the top element of the stack
-  DROP = 0x1,
-  // Duplicate the top element on the stack
-  DUPLICATE = 0x2,
-  // Return from a function
-  FUNCTION_RETURN = 0x3,
   // Call a Base9 function
-  FUNCTION_CALL = 0x4,
+  FUNCTION_CALL = 0x1,
+  // Return from a function
+  FUNCTION_RETURN = 0x2,
   // Call a native C function
-  PRIMITIVE_CALL = 0x5,
+  PRIMITIVE_CALL = 0x3,
   // Jump unconditionally by the offset
-  JMP = 0x6,
+  JMP = 0x4,
+  // Duplicate the top element on the stack
+  DUPLICATE = 0x5,
+  // Drop the top element of the stack
+  DROP = 0x6,
   // Push from a local variable
   PUSH_FROM_VAR = 0x7,
   // Push into a local variable
@@ -35,61 +36,67 @@ enum class ByteCode : RawByteCode {
 
   // Integer bytecodes
 
-  // Push a constant
-  INT_PUSH_CONSTANT = 0x9,
+  // Add two integers
+  INT_ADD = 0x9,
   // Subtract two integers
   INT_SUB = 0xa,
-  // Add two integers
-  INT_ADD = 0xb,
+
+  // CASCON2017 - Add INT_MUL and INT_DIV here
+
+  // Push a constant
+  INT_PUSH_CONSTANT = 0xd,
   // Jump if two integers are equal
-  INT_JMP_EQ = 0xc,
+  INT_JMP_EQ = 0xe,
   // Jump if two integer are not equal
-  INT_JMP_NEQ = 0xd,
+  INT_JMP_NEQ = 0xf,
   // Jump if the first integer is greater than the second
-  INT_JMP_GT = 0xe,
+  INT_JMP_GT = 0x10,
   // Jump if the first integer is greater than or equal to the second
-  INT_JMP_GE = 0xf,
+  INT_JMP_GE = 0x11,
   // Jump if the first integer is less than to the second
-  INT_JMP_LT = 0x10,
+  INT_JMP_LT = 0x12,
   // Jump if the first integer is less than or equal to the second
-  INT_JMP_LE = 0x11,
+  INT_JMP_LE = 0x13,
 
   // String ByteCodes
 
   // Push a string from this module's constant pool
-  STR_PUSH_CONSTANT = 0x12,
+  STR_PUSH_CONSTANT = 0x14,
   // Jump if two strings are equal
-  STR_JMP_EQ = 0x13,
-  // Jump if two integer are not equal
-  STR_JMP_NEQ = 0x14,
+  STR_JMP_EQ = 0x15,
+  // Jump if two strings are not equal
+  STR_JMP_NEQ = 0x16,
 };
 
 inline const char *toString(ByteCode bc) {
   switch (bc) {
     case ByteCode::END_SECTION:
       return "ByteCode::END_SECTION";
-    case ByteCode::DROP:
-      return "ByteCode::DROP";
-    case ByteCode::DUPLICATE:
-      return "ByteCode::DUPLICATE";
-    case ByteCode::FUNCTION_RETURN:
-      return "ByteCode::FUNCTION_RETURN";
     case ByteCode::FUNCTION_CALL:
-      return "ByteCode::FUNCTION_CALL";
+      return "FUNCTION_CALL";
+    case ByteCode::FUNCTION_RETURN:
+      return "FUNCTION_RETURN";
     case ByteCode::PRIMITIVE_CALL:
       return "ByteCode::PRIMITIVE_CALL";
     case ByteCode::JMP:
-      return "ByteCode::JMP";
+      return "JMP";
+    case ByteCode::DUPLICATE:
+      return "DUPLICATE";
+    case ByteCode::DROP:
+      return "DROP";
     case ByteCode::PUSH_FROM_VAR:
       return "ByteCode::PUSH_FROM_VAR";
     case ByteCode::POP_INTO_VAR:
-      return "ByteCode::POP_INTO_VAR";
-    case ByteCode::INT_PUSH_CONSTANT:
-      return "ByteCode::INT_PUSH_CONSTANT";
-    case ByteCode::INT_SUB:
-      return "ByteCode::INT_SUB";
+      return "POP_INTO_VAR";
     case ByteCode::INT_ADD:
-      return "ByteCode::INT_ADD";
+      return "INT_ADD";
+    case ByteCode::INT_SUB:
+      return "INT_SUB";
+
+    // CASCON2017 - Add INT_MUL and INT_DIV here
+
+    case ByteCode::INT_PUSH_CONSTANT:
+      return "INT_PUSH_CONSTANT";
     case ByteCode::INT_JMP_EQ:
       return "ByteCode::INT_JMP_EQ";
     case ByteCode::INT_JMP_NEQ:

--- a/b9/include/b9/interpreter.hpp
+++ b/b9/include/b9/interpreter.hpp
@@ -49,26 +49,28 @@ class ExecutionContext {
 
   void push(StackElement value);
   StackElement pop();
-  void drop();
-  void duplicate();
-  void functionReturn();
+
   void functionCall(Parameter value);
+  void functionReturn(StackElement returnVal);
   void primitiveCall(Parameter value);
+  void jmp(Parameter offset);
+  void duplicate();
+  void drop();
   void pushFromVar(StackElement *args, Parameter offset);
   void pushIntoVar(StackElement *args, Parameter offset);
-  void jmp(Parameter offset);
-
-  void intPushConstant(Parameter value);
   void intAdd();
   void intSub();
+  // CASCON2017 - Add intMul() and intDiv() here
+  void intPushConstant(Parameter value);
   Parameter intJmpEq(Parameter delta);
   Parameter intJmpNeq(Parameter delta);
   Parameter intJmpGt(Parameter delta);
   Parameter intJmpGe(Parameter delta);
   Parameter intJmpLt(Parameter delta);
   Parameter intJmpLe(Parameter delta);
-
   void strPushConstant(Parameter value);
+  // TODO: void strJmpEq(Parameter delta);
+  // TODO: void strJmpNeq(Parameter delta);
 
   // Reset the stack and other internal data
   void reset();

--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -757,16 +757,9 @@ function CodeGen(f) {
             this.currentFunction.pushN(-1); // pop 2, push 1
             return decl.operator;
         }
-        if (decl.operator == "*") {
-            this.outputInstruction("ByteCode::INT_MUL", 0, "");
-            this.currentFunction.pushN(-1); // pop 2, push 1
-            return decl.operator;
-        }
-        if (decl.operator == "/") {
-            this.outputInstruction("ByteCode::INT_DIV", 0, "");
-            this.currentFunction.pushN(-1); // pop 2, push 1
-            return decl.operator;
-        }
+        
+        // CASCON2017 - Add INT_MUL and INT_DIV here
+        
         var code = this.genJmpForCompare(decl.operator)
         if (code) {
             // this will be handled by the jmp which includes the compare operation (i.e jmple, jmpgt)


### PR DESCRIPTION
Put all bytecodes and handlers in a set order for consistency
and readability. Add CASCON2017 eye-catchers for the places to
implement integer multiplication and division.

Signed-off-by: Arianne Butler <arianne.butler@ibm.com>