### PR TITLE
Condense the Jitted Function types into one

### DIFF
--- a/b9/include/b9/interpreter.hpp
+++ b/b9/include/b9/interpreter.hpp
@@ -38,6 +38,8 @@ struct Stack {
   StackElement *stackPointer;
 };
 
+typedef StackElement (*JitFunction)(...);
+
 class ExecutionContext {
  public:
   ExecutionContext(VirtualMachine *virtualMachine, const Config &cfg)
@@ -103,11 +105,11 @@ class VirtualMachine {
   const FunctionSpec *getFunction(std::size_t index);
   PrimitiveFunction *getPrimitive(std::size_t index);
 
-  void *getJitAddress(std::size_t functionIndex);
-  void setJitAddress(std::size_t functionIndex, void *value);
+  JitFunction getJitAddress(std::size_t functionIndex);
+  void setJitAddress(std::size_t functionIndex, JitFunction value);
 
   std::size_t getFunctionCount();
-  uint8_t *generateCode(const FunctionSpec &functionSpec);
+  JitFunction generateCode(const FunctionSpec &functionSpec);
   void generateAllCode();
 
   const char *getString(int index);
@@ -121,18 +123,13 @@ class VirtualMachine {
   ExecutionContext executionContext_;
   std::shared_ptr<Compiler> compiler_;
   std::shared_ptr<const Module> module_;
-
-  std::vector<void *> compiledFunctions_;
+  std::vector<JitFunction> compiledFunctions_;
 };
 
 typedef StackElement (*Interpret)(ExecutionContext *context,
                                   const std::size_t functionIndex);
 
-typedef StackElement (*JIT_0_args)();
-typedef StackElement (*JIT_1_args)(StackElement p1);
-typedef StackElement (*JIT_2_args)(StackElement p1, StackElement p2);
-typedef StackElement (*JIT_3_args)(StackElement p1, StackElement p2,
-                                   StackElement p3);
+
 
 // define C callable Interpret API for each arg call
 // if args are passed to the function, they are not passed

--- a/b9/include/b9/jit.hpp
+++ b/b9/include/b9/jit.hpp
@@ -118,7 +118,7 @@ class MethodBuilder : public TR::MethodBuilder {
 class Compiler {
  public:
   Compiler(VirtualMachine *virtualMachine, const Config &cfg);
-  uint8_t *generateCode(const FunctionSpec &functionSpec);
+  JitFunction generateCode(const FunctionSpec &functionSpec);
 
  private:
   TR::TypeDictionary types_;

--- a/b9/jit.cpp
+++ b/b9/jit.cpp
@@ -76,7 +76,7 @@ Compiler::Compiler(VirtualMachine *virtualMachine, const Config &cfg)
   types_.CloseStruct("Stack");
 }
 
-uint8_t *Compiler::generateCode(const FunctionSpec &functionSpec) {
+JitFunction Compiler::generateCode(const FunctionSpec &functionSpec) {
   Stack *stack = virtualMachine_->executionContext()->stack();
   MethodBuilder methodBuilder(virtualMachine_, &types_, cfg_, functionSpec,
                               stack);
@@ -95,7 +95,7 @@ uint8_t *Compiler::generateCode(const FunctionSpec &functionSpec) {
     std::cout << "Compilation completed with return code: " << rc
               << ", code address: " << (void *)entry << std::endl;
 
-  return entry;
+  return (JitFunction)entry;
 }
 
 MethodBuilder::MethodBuilder(VirtualMachine *virtualMachine,
@@ -185,7 +185,7 @@ void MethodBuilder::defineFunctions() {
       auto function = virtualMachine_->getFunction(functionIndex);
       auto name = function->name.c_str();
       DefineFunction(name, (char *)__FILE__, name,
-                     virtualMachine_->getJitAddress(functionIndex), Int64,
+                     (void*)virtualMachine_->getJitAddress(functionIndex), Int64,
                      function->nargs, stackElementType, stackElementType,
                      stackElementType, stackElementType, stackElementType,
                      stackElementType, stackElementType, stackElementType);


### PR DESCRIPTION
Add CompiledFunctionPtr, a varargs function pointer. Use this type
everywhere reasonable. Remove the different jit passparam typedefs.

Signed-off-by: Robert Young <rwy0717@gmail.com>