### PR TITLE
Fix crash when function body is empty

### DIFF
--- a/b9/jit.cpp
+++ b/b9/jit.cpp
@@ -251,6 +251,13 @@ bool MethodBuilder::inlineProgramIntoBuilder(
 
   // Create a BytecodeBuilder for each Bytecode
   auto numberOfBytecodes = computeNumberOfBytecodes(program);
+  if (numberOfBytecodes == 0) {
+    if (cfg_.debug) {
+      std::cout << "unexpected EMPTY function body for " << function->name << std::endl;
+    }
+    return false;
+  }
+
   if (cfg_.debug)
     std::cout << "Creating " << numberOfBytecodes << " bytecode builders\n";
   std::vector<TR::BytecodeBuilder *> builderTable;

--- a/test/interpreter_test.src
+++ b/test/interpreter_test.src
@@ -215,6 +215,7 @@ function test_while() {
     }
     return 1;
 }
+
 function b9main() {
 }
 


### PR DESCRIPTION
1. Currently JIT compiler assumes a non-empty function body, and when it
encounters an empty function, it crashes. Fix is to check the method's number
of bytecodes and abort compile when there is 0 bytecodes.
2. In file test/interpreter_test.src, add CASCON2017 eye-catcher in b9main.

Signed-off-by: Xiaoli Liang <xliang6@gmail.com>