### PR TITLE
Don't crash when a function doesn't compile

### DIFF
--- a/b9/core.cpp
+++ b/b9/core.cpp
@@ -351,7 +351,14 @@ const FunctionSpec *VirtualMachine::getFunction(std::size_t index) {
 }
 
 JitFunction VirtualMachine::generateCode(const std::size_t functionIndex) {
-  return compiler_->generateCode(functionIndex);
+  try {
+    return compiler_->generateCode(functionIndex);
+  } catch (const CompilationException& e) {
+    auto f = getFunction(functionIndex);
+    std::cerr << "Warning: Failed to compile " << f << std::endl;
+    std::cerr << "    with error: " << e.what() << std::endl;
+    return nullptr;
+  }
 }
 
 const char *VirtualMachine::getString(int index) {


### PR DESCRIPTION
Just print an error. Sometimes we throw an exception, sometimes we just return false/null. This will catch the compile exceptions and print an error.

Signed-off-by: Robert Young <rwy0717@gmail.com>