### PR TITLE
Change instructions to vector in FunctionSpec

### DIFF
--- a/b9/core.cpp
+++ b/b9/core.cpp
@@ -244,7 +244,7 @@ StackElement ExecutionContext::interpret(const std::size_t functionIndex) {
   }
 
   // interpret the method otherwise
-  const Instruction *instructionPointer = function->address;
+  const Instruction *instructionPointer = function->instructions.data();
   StackElement *args = stackPointer_ - function->nargs;
   stackPointer_ += function->nregs;
 

--- a/b9/include/b9/module.hpp
+++ b/b9/include/b9/module.hpp
@@ -13,20 +13,24 @@ class Compiler;
 class ExecutionContext;
 class VirtualMachine;
 
-/// Function specification. Metadata about a function.
+/// Function specification copy constructor. Metadata about a function.
 struct FunctionSpec {
-  FunctionSpec(const std::string& name, const Instruction* address,
+  FunctionSpec(const std::string& name, const std::vector<Instruction> &instructions,
                std::uint32_t nargs = 0, std::uint32_t nregs = 0)
-      : address{address}, nargs{nargs}, nregs{nregs}, name{name} {}
+      : instructions{instructions}, nargs{nargs}, nregs{nregs}, name{name} {}
 
-  const Instruction* address;
+  FunctionSpec(const std::string& name, std::vector<Instruction> &&instructions,
+               std::uint32_t nargs = 0, std::uint32_t nregs = 0)
+      : instructions{std::move(instructions)}, nargs{nargs}, nregs{nregs}, name{name} {}  
+
+  std::vector<Instruction> instructions;
   std::uint32_t nargs;
   std::uint32_t nregs;
   std::string name;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const FunctionSpec& f) {
-  return out << f.name << " (" << f.address << "): {nargs: " << f.nargs
+  return out << f.name << " (" << &(f.instructions) << "): {nargs: " << f.nargs
              << ", nregs: " << f.nregs << "}";
 }
 

--- a/b9/jit.cpp
+++ b/b9/jit.cpp
@@ -249,7 +249,7 @@ bool MethodBuilder::inlineProgramIntoBuilder(
   bool success = true;
   maxInlineDepth--;
   const FunctionSpec *function = virtualMachine_->getFunction(functionIndex);
-  const Instruction *program = function->address;
+  const Instruction *program = function->instructions.data();
 
   // Create a BytecodeBuilder for each Bytecode
   auto numberOfBytecodes = computeNumberOfBytecodes(program);
@@ -500,7 +500,7 @@ bool MethodBuilder::generateILForBytecode(
     case ByteCode::FUNCTION_CALL: {
       const std::size_t callindex = instruction.parameter();
       const FunctionSpec *callee = virtualMachine_->getFunction(callindex);
-      const Instruction *tocall = callee->address;
+      const Instruction *tocall = callee->instructions.data();
       const std::uint32_t argsCount = callee->nargs;
       const std::uint32_t regsCount = callee->nregs;
 

--- a/b9/loader.cpp
+++ b/b9/loader.cpp
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include <dlfcn.h>
 #include <b9/loader.hpp>
 
@@ -27,7 +29,14 @@ void DlLoader::loadFunctions(const std::shared_ptr<Module>& module,
   auto table = loadSymbol<const DlFunctionTable>(handle, "b9_function_table");
   for (std::size_t i = 0; i < table->length; i++) {
     auto& entry = table->functions[i];
-    module->functions.emplace_back(entry.name, entry.address, entry.nargs,
+    const Instruction *ip = entry.address;
+    auto instructions = std::vector<Instruction>();
+    while (*ip != END_SECTION) {
+      instructions.push_back(*ip); 
+      ++ip;
+    }
+    instructions.push_back(END_SECTION);
+    module->functions.emplace_back(entry.name, std::move(instructions), entry.nargs,
                                    entry.nregs);
   }
 }

--- a/test/b9test.cpp
+++ b/test/b9test.cpp
@@ -122,7 +122,7 @@ TEST_F(InterpreterTest, jit_lvms) {
 TEST(MyTest, arguments) {
   b9::VirtualMachine vm{{}};
   auto m = std::make_shared<Module>();
-  Instruction i[] = {{ByteCode::PUSH_FROM_VAR, 0},
+  std::vector<Instruction> i = {{ByteCode::PUSH_FROM_VAR, 0},
                      {ByteCode::PUSH_FROM_VAR, 1},
                      {ByteCode::INT_ADD},
                      {ByteCode::FUNCTION_RETURN},


### PR DESCRIPTION
Changed the instruction pointer to a Instruction vector

Signed-off-by: Arianne Butler <arianne.butler@ibm.com>