### PR TITLE
Zero new elements when calling OperandStack::pushn()

### DIFF
--- a/b9/include/b9/OperandStack.hpp
+++ b/b9/include/b9/OperandStack.hpp
@@ -26,6 +26,7 @@ class OperandStack {
   }
 
   StackElement *pushn(std::size_t n) {
+    memset(top_, 0, sizeof(*top_)* n);
     top_ += n;
     return top_;
   }


### PR DESCRIPTION
This is done mainly so that locals are zeroed on function entry

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>