### PR TITLE
Fix compile.js to work with older node versions.

### DIFF
--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -11,7 +11,7 @@ function outputUInt32(out, value) {
 
 	var buf = Buffer.allocUnsafe(4);
 	buf.writeUInt32LE(value, 0);
-	fs.writeSync(out, buf);
+	fs.writeSync(out, buf, 0, 4);
 }
 
 function outputString(out, string) {


### PR DESCRIPTION
Older node versions detect `fs.writeSync(fd, var)` as a call to `fs.writeSync(fd, string[, position[, encoding]])` which, if var is a buffer, causes nothing to be written to the file. By adding the eextra args we force detection as `writeSync(fd, buffer[, offset[, length[, position]]])`