### PR TITLE
Compiler: fix arg handling in function declaration

### DIFF
--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -393,7 +393,7 @@ function FirstPassCodeGen() {
 	this.handleFunctionDeclaration = function (func, declaration) {
 		var inner = this.module.functions.newFunctionDefinition(declaration.id.name, func);
 		declaration.params.forEach(function (param) {
-			inner.args.get(param);
+			inner.args.get(param.name);
 		});
 		inner.nargs = declaration.params.length;
 		this.handle(inner, declaration.body);


### PR DESCRIPTION
Update code to register the name of the function parameters, rather than the `Identifier` object from the parse tree.
Old behavior only coincidentally worked, for functions with no more than 1 argument.