### PR TITLE
Use Buffer.alloc for older node.js support

### DIFF
--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -8,8 +8,7 @@ var esprima = require('esprima');
 var fs = require('fs');
 
 function outputUInt32(out, value) {
-
-	var buf = Buffer.allocUnsafe(4);
+	var buf = Buffer.alloc(4);
 	buf.writeUInt32LE(value, 0);
 	fs.writeSync(out, buf, 0, 4);
 }


### PR DESCRIPTION
unsafeAlloc is faster, but alloc is supported on older versions of node.

Signed-off-by: Robert Young <rwy0717@gmail.com>