### PR TITLE
Update README [skip-ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,47 @@
-# Welcome to Base9!
+# Welcome to b9!
 
 [![Build Status](https://api.travis-ci.org/b9org/b9.svg?branch=master)](https://travis-ci.org/b9org/b9)
 [![Coverage Status](https://coveralls.io/repos/github/b9org/b9/badge.svg?branch=master)](https://coveralls.io/github/b9org/b9?branch=master)
 
-b9 is an educational language runtime and programming language! We’re using it to show people how to use
-[Eclipse OMR] to build their own language runtime with a Just in Time (JIT) Compiler! The b9 language, b9porcelain, is a simple subset of JavaScript.
+b9 is an educational language runtime and programming language! We’re using it to show people how to use [Eclipse OMR] to build their own language runtime with a Just in Time (JIT) Compiler! The b9 language, b9porcelain, is a simple subset of JavaScript.
 
 [Eclipse OMR]: https://github.com/eclipse/omr
 
-This page contains basic instructions on building b9 in an Ubuntu 16.04 environment.
-You may copy each of the blocks of commands and paste them in the terminal.
-Depending on your user privileges, you may need to precede some of commands with
-sudo in steps 1 and 3. For more detailed instructions, check out our 
-[set-up page](./docs/SetupBase9.md).
+# Getting started
+
+This page contains some basic instructions to get you started. For more detailed instructions, go to:
+* [Ubuntu set-up page](./docs/SetupUbuntu.md).
+* [OSX set-up page](./docs/SetupOSX.md).
 
 ### 1. Requirements
 
-To get started with b9 on Ubuntu 16.04, you'll need the following:
+To get started with b9 using the Ninja build system, you'll need the following:
 
 * `git` 
 * `build-essential`
-* `nodejs`
-* `npm` 
-* `cmake` 
+* `nodejs` **(Minimum version 4.5.0)**
+* `npm`
+* `esprima`
+* `cmake` **(Minimum version 3.2.0)**
 * `ninja`
-
-To install the applications above, run the following command
-```plaintext
-apt-get update && apt-get install git build-essential nodejs npm cmake ninja
-```
 
 ### 2. Clone the repository and get the submodules
 
-```
-git clone --recursive https://github.com/b9org/b9.git \
-&& cd b9 \
-&& git submodule update --init \
-&& cd ..
+```sh
+git clone --recursive https://github.com/b9org/b9.git
 ```
 
-### 3. Upgrade and create link for nodejs and install esprima
+### 3. Install Esprima
 
-```plaintext
-npm install -g n \
-&& n latest \
-&& ln -s /usr/local/bin/node /usr/bin/node \
-&& cd b9 \
+```sh
+cd b9 \
 && npm install esprima \
 && cd ..
 ```
 
 ### 4. Build b9
 
-```
+```sh
 mkdir build \
 && cd build \
 && cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ../b9 \
@@ -61,15 +50,19 @@ mkdir build \
 
 ### 5. Run Hello World!
 
-Ensure you're in the build directory and run:
+In the `build` directory, run:
 
-`./b9run/b9run ./test/hello.b9mod`
+```sh
+./b9run/b9run ./test/hello.b9mod
+```
 
 ### 6. Test b9
 
 You can run the full b9 test suite with:
 
-`ninja test`
+```sh
+ninja test
+```
 
 ## Build your own Language Runtime
 

--- a/README.md
+++ b/README.md
@@ -3,50 +3,76 @@
 [![Build Status](https://api.travis-ci.org/b9org/b9.svg?branch=master)](https://travis-ci.org/b9org/b9)
 [![Coverage Status](https://coveralls.io/repos/github/b9org/b9/badge.svg?branch=master)](https://coveralls.io/github/b9org/b9?branch=master)
 
-Base9 is an educational language runtime and programming language! We’re using it to show people how to use
-[Eclipse OMR] to build their own language runtime with a Just in Time (JIT) Compiler! The Base9 language, b9porcelain, is a simple subset of JavaScript.
+b9 is an educational language runtime and programming language! We’re using it to show people how to use
+[Eclipse OMR] to build their own language runtime with a Just in Time (JIT) Compiler! The b9 language, b9porcelain, is a simple subset of JavaScript.
 
 [Eclipse OMR]: https://github.com/eclipse/omr
 
-## Requirements
+This page contains basic instructions on building b9 in an Ubuntu 16.04 environment.
+You may copy each of the blocks of commands and paste them in the terminal.
+Depending on your user privileges, you may need to precede some of commands with
+sudo in steps 1 and 3. For more detailed instructions, check out our 
+[set-up page](./docs/SetupBase9.md).
 
-To get started with Base9, you'll need:
+### 1. Requirements
 
-`git, build-essential, nodejs, npm, esprima, cmake, ninja` 
+To get started with b9 on Ubuntu 16.04, you'll need the following:
 
-For detailed instructions on setting up Base9, check out our [set-up page](./docs/SetupBase9.md).
+* `git` 
+* `build-essential`
+* `nodejs`
+* `npm` 
+* `cmake` 
+* `ninja`
 
-
-## Clone the repository and get the submodules
-
-```
-git clone --recursive https://github.com/b9org/b9.git
-cd Base9
-git submodule update --init
-```
-
-## Build Base9
-
-```
-mkdir build && cd build
-cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
-ninja
+To install the applications above, run the following command
+```plaintext
+apt-get update && apt-get install git build-essential nodejs npm cmake ninja
 ```
 
-## Run Hello World!
+### 2. Clone the repository and get the submodules
+
+```
+git clone --recursive https://github.com/b9org/b9.git \
+&& cd b9 \
+&& git submodule update --init \
+&& cd ..
+```
+
+### 3. Upgrade and create link for nodejs and install esprima
+
+```plaintext
+npm install -g n \
+&& n latest \
+&& ln -s /usr/local/bin/node /usr/bin/node \
+&& cd b9 \
+&& npm install esprima \
+&& cd ..
+```
+
+### 4. Build b9
+
+```
+mkdir build \
+&& cd build \
+&& cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ../b9 \
+&& ninja
+```
+
+### 5. Run Hello World!
 
 Ensure you're in the build directory and run:
 
 `./b9run/b9run ./test/hello.b9mod`
 
-## Test Base9
+### 6. Test b9
 
-You can run the full Base9 test suite with:
+You can run the full b9 test suite with:
 
 `ninja test`
 
 ## Build your own Language Runtime
 
-If you'd like to build your own language runtime, you can follow our [Developer Journey] to see the steps we took in building Base9.
+If you'd like to build your own language runtime, you can follow our [Developer Journey] to see the steps we took in building b9.
 
 [Developer Journey]: ./docs/DeveloperJourney.md

--- a/docs/SetupOSX.md
+++ b/docs/SetupOSX.md
@@ -5,17 +5,60 @@ title: OSX Setup
 
 ## Setting up Base9 on OSX
 
-Get homebrew: https://brew.sh/
+### 1. Requirements
 
-`sudo xcode-select --install`
+If you do not already have the OSX command line tools installed, then you may do so by running the following command in the terminal.
 
-`brew install <item>`
-
-items:
+```sh
+sudo xcode-select --install
 ```
-git
-node
-npm
-cmake
-ninja
+
+To get started with b9 using the Ninja build system, you'll need the following:
+
+* `git` 
+* `node`
+* `npm`
+* `cmake`
+* `ninja`
+
+To install the above packages, you may use [homebrew](https://brew.sh/) and run the following command in the terminal:
+```sh
+brew install git node npm cmake ninja
+```
+
+### 2. Clone the repository and get the submodules
+
+```sh
+cd ~ \
+&& git clone --recursive https://github.com/b9org/b9.git
+```
+
+### 3. Install Esprima
+```sh
+cd b9 \
+&& npm install esprima
+```
+### 4. Build b9
+
+```sh
+mkdir build \
+&& cd build \
+&& cmake -GNinja -DCMAKE_BUILD_TYPE=Debug .. \
+&& ninja
+```
+
+### 5. Run Hello World!
+
+Ensure you're still in the `build` directory and run:
+
+```sh
+./b9run/b9run ./test/hello.b9mod
+```
+
+### 6. Test b9
+
+You can run the full b9 test suite with:
+
+```sh
+ninja test
 ```

--- a/docs/SetupOSX.md
+++ b/docs/SetupOSX.md
@@ -29,8 +29,7 @@ brew install git node npm cmake ninja
 ### 2. Clone the repository and get the submodules
 
 ```sh
-cd ~ \
-&& git clone --recursive https://github.com/b9org/b9.git
+git clone --recursive https://github.com/b9org/b9.git
 ```
 
 ### 3. Install Esprima

--- a/docs/SetupUbuntu.md
+++ b/docs/SetupUbuntu.md
@@ -30,26 +30,22 @@ apt-get update && apt-get install git build-essential nodejs npm cmake
 git clone --recursive https://github.com/b9org/b9.git
 ```
 
-### 3. Create link for nodejs v4.5+
 
-Building b9 requires nodejs version 4.5+. The default nodejs versions
-in Ubuntu 16.04 and older do not meet this requirement, so you may have to upgrade your nodejs. There are several ways to do it, and [this
-is one way](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions) we can recommend.
+### 3. Upgrading node.js
 
-Assuming you now have nodejs v4.5+, create a link using the command below:
-```sh
-ln -s $NODEJS_BIN /usr/bin/node
-```
-Variable `NODEJS_BIN` must be the location of where your nodejs version 4.5+ executable is located. Here is an example of how this may look like:
+If you are running Ubuntu 16.04 and older, your nodejs may be older than version 4.5, in
+which case you will need to upgrade it. You can install newer nodejs binaries from 
+[NodeSource](https://nodesource.com/)'s PPA using:
 
 ```sh
-ln -s /usr/local/bin/nodejs /usr/bin/node
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - \
+&& sudo apt-get install -y nodejs
 ```
 
-You may verify that /usr/bin/node is indeed a link to version 4.5+ by running:
-```sh
-/usr/bin/node -v
-```
+Check out [this](https://nodejs.org/en/download/package-manager) guide for more information 
+on obtaining node.js packages.
+
+You may run `nodejs -v` to verify that your nodejs version is 4.5.0 or above.
 
 ### 4. Install Esprima
 ```sh

--- a/docs/SetupUbuntu.md
+++ b/docs/SetupUbuntu.md
@@ -5,14 +5,78 @@ title: Ubuntu Setup
 
 ## Setting up Base9 on Ubuntu
 
-`sudo apt-get install <item>`
+Depending on your user privileges, you may have to precede some of the
+commands in the steps below with `sudo`.
+### 1. Requirements
 
-items:
+To get started with b9 using the Ninja build system, you'll need the following:
+
+* `git` 
+* `build-essential`
+* `nodejs` **(Minimum version 4.5.0)**
+* `npm`
+* `cmake` **(Minimum version 3.2.0)**
+* `ninja`
+
+You can install the packages above using the following command:
+
+```sh
+apt-get update && apt-get install git build-essential nodejs npm cmake
 ```
-git
-build-essential
-npm
-nodejs           
-cmake           
-ninja-build
+
+### 2. Clone the repository and get the submodules
+
+```sh
+git clone --recursive https://github.com/b9org/b9.git
+```
+
+### 3. Create link for nodejs v4.5+
+
+Building b9 requires nodejs version 4.5+. The default nodejs versions
+in Ubuntu 16.04 and older do not meet this requirement, so you may have to upgrade your nodejs. There are several ways to do it, and [this
+is one way](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions) we can recommend.
+
+Assuming you now have nodejs v4.5+, create a link using the command below:
+```sh
+ln -s $NODEJS_BIN /usr/bin/node
+```
+Variable `NODEJS_BIN` must be the location of where your nodejs version 4.5+ executable is located. Here is an example of how this may look like:
+
+```sh
+ln -s /usr/local/bin/nodejs /usr/bin/node
+```
+
+You may verify that /usr/bin/node is indeed a link to version 4.5+ by running:
+```sh
+/usr/bin/node -v
+```
+
+### 4. Install Esprima
+```sh
+cd b9 \
+&& npm install esprima
+```
+### 4. Build b9
+
+```sh
+mkdir build \
+&& cd build \
+&& cmake -GNinja -DCMAKE_BUILD_TYPE=Debug .. \
+&& ninja
+```
+
+### 5. Run Hello World!
+
+Ensure you're in the build directory and run:
+
+```sh
+./b9run/b9run ./test/hello.b9mod
+```
+
+### 6. Test b9
+
+You can run the full b9 test suite with:
+
+```sh
+ninja test
 ```


### PR DESCRIPTION
This patch updates the README file to contain more up-to-date
information on building b9. There were some missing steps
that have now been addressed.

The README file contains instructions on how to build b9
on Ubuntu 16.04. The steps here make users update their
nodejs to the latest version to ensure all features being
used in the project are available.

Also, I switched the instructions to build out of source tree
as it is a cleaner approach in my opinion.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>