### PR TITLE
Initial side navigation implementation for Developer Journey

### DIFF
--- a/docs/BuildARuntime.md
+++ b/docs/BuildARuntime.md
@@ -3,13 +3,6 @@ layout: devJourney
 title: Build your own Language Runtime
 ---
 
-* Table of Contents
-{:toc}
-
-```
-
-```
-
 ## Introduction
 
 Welcome to the tutorial! If you're interested in building your own [language runtime], you've come to the right place. Base9 is a miniature language runtime, and thanks to [OMR] and [JitBuilder], it even has a [Just In Time (JIT) Compiler]! The goal of this tutorial is not to teach you how to build base9, but rather to pack your arsenal full of tools to build your own language runtime. We don't want to bog you down with a bunch of unnecessary information, so we'll keep things very straightfoward, providing useful links/definitions along the way for you to peruse optionally and at your own convenience. If you'd like to get familiar with some of the vocabulary you'll encounter, feel free to visit the [tutorial dictionary].

--- a/docs/_includes/sideNavbar.liquid
+++ b/docs/_includes/sideNavbar.liquid
@@ -1,16 +1,48 @@
-<nav id="navbar-example3" class="navbar navbar-light bg-light">
+<div id="dev-journey-sidenav" class="sidenav">
   <nav class="nav nav-pills flex-column">
-    <a class="nav-link" href="#item-1">Item 1</a>
+
+    <a class="nav-link" href="#introduction">Introduction</a>
     <nav class="nav nav-pills flex-column">
-      <a class="nav-link ml-3 my-1" href="#item-1-1">Item 1-1</a>
-      <a class="nav-link ml-3 my-1" href="#item-1-2">Item 1-2</a>
+      <a class="nav-link ml-3 my-1" href="#base9-setup">Base9 Setup</a>
+      <a class="nav-link ml-3 my-1" href="#base9-overview">Base9 Overview</a>
     </nav>
-    <a class="nav-link" href="#item-2">Item2</a>
-    <a class="nav-link" href="#item-3">Item3</a>
+
+    <a class="nav-link" href="#the-base9-frontend">The Base9 Frontend</a>
     <nav class="nav nav-pills flex-column">
-      <a class="nav-link ml-3 my-1" href="#item-3-1">Item 3-1</a>
-      <a class="nav-link ml-3 my-1" href="#item-3-2">Item 3-2</a>
+      <a class="nav-link ml-3 my-1" href="#frontend-language">Frontend Language</a>
+      <a class="nav-link ml-3 my-1" href="#frontend-compiler">Frontend Compiler</a>
+    </nav>
+
+    <a class="nav-link" href="#the-base9-backend">The Base9 Backend</a>
+    <nav class="nav nav-pills flex-column">
+      <a class="nav-link ml-3 my-1" href="#the-deserializer">The Deserializer</a>
+      <a class="nav-link ml-3 my-1" href="#the-base9-bytecodes">The Base9 Bytecodes</a>
+      <a class="nav-link ml-3 my-1" href="#the-stack">The Stack</a>
+      <a class="nav-link ml-3 my-1" href="#the-virtual-machine">The Virtual Machine</a>
+      <a class="nav-link ml-3 my-1" href="#the-interpreter">The Interpreter</a>
+    </nav>
+
+    <a class="nav-link" href="#base9-implementation">Base9 Implementation</a>
+    <nav class="nav nav-pills flex-column">
+      <a class="nav-link ml-3 my-1" href="#the-main-function">The "main" Function</a>
+      <a class="nav-link ml-3 my-1" href="#the-run-function">The "run" Function</a>
+      <a class="nav-link ml-3 my-1" href="#the-in-memory-module">The in memory module</a>
+      <a class="nav-link ml-3 my-1" href="#the-interpreter-loop">The Interpreter Loop</a>
+      <a class="nav-link ml-3 my-1" href="#implementation-summary">Implementation Summary</a>
+    </nav>
+
+    <a class="nav-link" href="#omr-and-jitbuilder">OMR and JitBuilder</a>
+    <nav class="nav nav-pills flex-column">
+      <a class="nav-link ml-3 my-1" href="#omr">OMR</a>
+      <a class="nav-link ml-3 my-1" href="#jitbuilder">JitBuilder</a>
+    </nav>
+
+    <a class="nav-link" href="#integrate-the-jit-compiler">Integrate The Jit Compiler</a>
+    <nav class="nav nav-pills flex-column">
+      <a class="nav-link ml-3 my-1" href="#the-jit-compiler">The Jit Compiler</a>
+      <a class="nav-link ml-3 my-1" href="#plugging-in-the-jit">Plugging in the JIT</a>
+      <a class="nav-link ml-3 my-1" href="#jit-features">JIT Features</a>
     </nav>
   </nav>
-</nav>
+</div>
 

--- a/docs/_layouts/devJourney.liquid
+++ b/docs/_layouts/devJourney.liquid
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+  {%- include sideNavbar.liquid -%}
   <h1>{{page.title}}</h2>
   <h2>Table of Contents</h2>
     {{ content }}

--- a/docs/_layouts/devJourney.liquid
+++ b/docs/_layouts/devJourney.liquid
@@ -3,5 +3,4 @@ layout: default
 ---
   {%- include sideNavbar.liquid -%}
   <h1>{{page.title}}</h2>
-  <h2>Table of Contents</h2>
     {{ content }}

--- a/docs/_sass/minima/_layout.scss
+++ b/docs/_sass/minima/_layout.scss
@@ -1,9 +1,52 @@
-/* Navigation Bar  */
+/* top navigation bar*/
+.navbar-nav{
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 70px;
+	position: fixed; //stay fixed to top
+	overflow-x: hidden;
+	padding-top: 10px;
+	padding-bottom: 10px;
+	z-index:1; //appear on top of everything else
+}
+
+.navbar{
+	top: 0;
+	left: 0;
+	height: 70px;
+	width: 100%;
+	position: fixed;
+	overflow-x: hidden;
+	padding-top: 10px;
+	padding-bottom: 10px;
+	z-index:1;
+}
+
+
+/* Navigation Bar list item */
 .navbar-nav > li{
   padding-left:30px;
   padding-right:30px;
   margin-left:-10px;
-  margin-right:-10px;
+	margin-right:-10px;
+}
+
+/* Sidenav menu for dev journey */
+.sidenav {
+	height: 100%;
+	width: 15%;
+	position: fixed; //stay fixed to left side
+	top: 0;
+	left: 0;
+	background-color: $b9-yellow;
+	overflow-x: hidden; /* disable horizontal scroll */
+	padding-top: 70px; /* place sidenav contents 60px from the top */
+}
+
+.sidenav a {
+	font-size: 14px;
+	line-height: 1;
 }
 
 /* Defaults */
@@ -17,7 +60,7 @@ main {
 	margin: 0 auto;
 }
 body {
-	margin: 0;
+	margin: 70px;
 	color: $main;
 	font-family: $font-style;
 	font-size: 1.1em;


### PR DESCRIPTION
This is the initial set of changes to have a basic
side navigation feature for devjourney. It does everything
that clicking on the table of content items do. The side
navigation bar remains fixed while scrolling. Also,
the top navigation bar has also been set to remain fixed,
making navigation between pages easier.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

I have been unable to publish it so far due to github pages build error. However, it does work locally. @arianneb Please see if you face the same problem while publishing through gh pages.

Here is a screenshot of how it looks like:

<img width="719" alt="screen shot 2018-04-23 at 6 41 44 pm" src="https://user-images.githubusercontent.com/23691212/39156876-226ef2f2-4726-11e8-98a9-0911fdb7d3e8.png">
