### PR TITLE
Augment AST before generating module

### DIFF
--- a/b9/src/ExecutionContext.cpp
+++ b/b9/src/ExecutionContext.cpp
@@ -189,7 +189,8 @@ StackElement ExecutionContext::interpret(const std::size_t functionIndex) {
     instructionPointer++;
     programCounter_++;
   }
-  throw std::runtime_error("Reached end of function");
+  //throw std::runtime_error("Reached end of function");
+  return StackElement(0);
 }
 
 void ExecutionContext::push(StackElement value) { stack_.push(value); }

--- a/b9/src/ExecutionContext.cpp
+++ b/b9/src/ExecutionContext.cpp
@@ -189,8 +189,7 @@ StackElement ExecutionContext::interpret(const std::size_t functionIndex) {
     instructionPointer++;
     programCounter_++;
   }
-  //throw std::runtime_error("Reached end of function");
-  return StackElement(0);
+  throw std::runtime_error("Reached end of function");
 }
 
 void ExecutionContext::push(StackElement value) { stack_.push(value); }

--- a/b9/src/VirtualMachine.cpp
+++ b/b9/src/VirtualMachine.cpp
@@ -99,12 +99,13 @@ std::size_t VirtualMachine::getFunctionCount() {
 
 void VirtualMachine::generateAllCode() {
   assert(cfg_.jit);
-  auto functionIndex = 0;
+  compiledFunctions_.push_back(nullptr); //TODO: <body> function right now is "compiled" as null
+  auto functionIndex = 1; //0 index for <body>
 
   while (functionIndex < getFunctionCount()) {
     if (cfg_.debug)
       std::cout << "\nJitting function: " << getFunction(functionIndex)->name
-                << std::endl;
+                << " of index: " << functionIndex << std::endl;
     auto func = compiler_->generateCode(functionIndex);
     compiledFunctions_.push_back(func);
     ++functionIndex;

--- a/b9/src/VirtualMachine.cpp
+++ b/b9/src/VirtualMachine.cpp
@@ -99,8 +99,7 @@ std::size_t VirtualMachine::getFunctionCount() {
 
 void VirtualMachine::generateAllCode() {
   assert(cfg_.jit);
-  compiledFunctions_.push_back(nullptr); //TODO: <body> function right now is "compiled" as null
-  auto functionIndex = 1; //0 index for <body>
+  auto functionIndex = 0; //0 index for <body>
 
   while (functionIndex < getFunctionCount()) {
     if (cfg_.debug)

--- a/b9run/main.cpp
+++ b/b9run/main.cpp
@@ -35,7 +35,7 @@ static const char* usage =
 struct RunConfig {
   b9::Config b9;
   const char* moduleName = "";
-  const char* mainFunction = "b9main";
+  const char* mainFunction = "<body>";
   std::size_t loopCount = 1;
   bool verbose = false;
   std::vector<b9::StackElement> usrArgs;

--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -148,7 +148,6 @@ function BlockEntry(globalContext) { //currently unused
 		if (id !== undefined) {
 			return { type: "function", id: id };
 		}
-		//console.warn("Did not find symbol: " + symbol + " in: " + JSON.stringify(this, null, 2));
 		return undefined;
 	}
 
@@ -438,6 +437,8 @@ function FirstPassCodeGen() {
 		this.augmentAST(syntax);
 		this.functionContext.enterFunction(syntax.functionEntry);
 		this.handleBody(func, syntax.body);
+		func.instructions.push(new Instruction("INT_PUSH_CONSTANT", 0));
+		func.instructions.push(new Instruction("FUNCTION_RETURN", 0));
 		func.instructions.push(new Instruction("END_SECTION", 0)); //end of top level function
 		this.functionContext.exitFunction(); 
 		return this.module;


### PR DESCRIPTION
Some of the AST nodes now have a functionEntry member that
provides a way to lookup symbols defined in parent scopes.
FunctionContext is used for context tracking as well
as looking up symbols beyond local context through the use
of a stack. Function indexing starts from 1, as index 0 is
reserved for the top-level body, which is now treated as a
function.

Also-by: Robert Young <rwy0717@gmail.com>
Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>