### PR TITLE
Rename byteCode to opCode in more places

### DIFF
--- a/b9/include/b9/instructions.hpp
+++ b/b9/include/b9/instructions.hpp
@@ -33,7 +33,7 @@ enum class OpCode : RawOpCode {
   // Push into a local variable
   POP_INTO_VAR = 0x8,
 
-  // Integer bytecodes
+  // Integer opcodes
 
   // Add two integers
   INT_ADD = 0x9,
@@ -159,11 +159,11 @@ using RawInstruction = std::uint32_t;
 /// signed values, so special care must be taken to sign extend 24bits to 32.
 using Immediate = std::int32_t;
 
-/// A RawInstruction wrapper that will encode and decode instruction bytecodes
+/// A RawInstruction wrapper that will encode and decode instruction opcodes
 /// and immediate parameters. The Instruction layout is:
 /// ```
 /// |0000-0000 0000-0000 0000-0000 0000-0000
-/// |---------| bytecode (8bits)
+/// |---------| opcode (8bits)
 ///           |-----------------------------| immediate (24bits)
 /// ```
 ///
@@ -185,14 +185,14 @@ class Instruction {
     return *this;
   }
 
-  /// Encode the bytecode
-  constexpr Instruction &byteCode(OpCode op) noexcept {
+  /// Encode the opcode
+  constexpr Instruction &opCode(OpCode op) noexcept {
     raw_ = (RawInstruction(op) << OPCODE_SHIFT) | (raw_ & IMMEDIATE_MASK);
     return *this;
   }
 
-  /// Decode the bytecode
-  constexpr OpCode byteCode() const noexcept {
+  /// Decode the opcode
+  constexpr OpCode opCode() const noexcept {
     return static_cast<OpCode>(raw_ >> OPCODE_SHIFT);
   }
 
@@ -229,14 +229,14 @@ class Instruction {
 };
 
 /// A special constant indicating the end of a sequence of instructions.
-/// END_SECTION should be the last element in every functions bytecode array.
+/// END_SECTION should be the last element in every functions opcode array.
 static constexpr Instruction END_SECTION{OpCode::END_SECTION, 0};
 
 /// Print an Instruction.
 inline std::ostream &operator<<(std::ostream &out, Instruction i) {
-  out << "(" << i.byteCode();
+  out << "(" << i.opCode();
 
-  switch (i.byteCode()) {
+  switch (i.opCode()) {
     // 0 parameters
     case OpCode::END_SECTION:
     case OpCode::DUPLICATE:

--- a/b9/src/ExecutionContext.cpp
+++ b/b9/src/ExecutionContext.cpp
@@ -93,7 +93,7 @@ StackElement ExecutionContext::interpret(const std::size_t functionIndex) {
   stack_.pushn(function->nregs);
 
   while (*instructionPointer != END_SECTION) {
-    switch (instructionPointer->byteCode()) {
+    switch (instructionPointer->opCode()) {
       case OpCode::FUNCTION_CALL:
         doFunctionCall(instructionPointer->immediate());
         break;

--- a/b9/src/MethodBuilder.cpp
+++ b/b9/src/MethodBuilder.cpp
@@ -334,7 +334,7 @@ bool MethodBuilder::generateILForBytecode(
     //               builder->ConstInt64(instruction.raw()));
   }
 
-  switch (instruction.byteCode()) {
+  switch (instruction.opCode()) {
     case OpCode::PUSH_FROM_VAR:
       push(builder, loadVarIndex(builder, instruction.immediate()));
       if (nextBytecodeBuilder)

--- a/docs/build-a-runtime/index.md
+++ b/docs/build-a-runtime/index.md
@@ -527,7 +527,7 @@ Now let's take a look at the while-loop and switch-statement.
 
 ```cpp
   while (*instructionPointer != END_SECTION) {
-    switch (instructionPointer->byteCode()) {
+    switch (instructionPointer->opCode()) {
 
       ...
 
@@ -796,7 +796,7 @@ bool MethodBuilder::generateILForBytecode(
 
   bool handled = true;
 
-  switch (instruction.byteCode()) {
+  switch (instruction.opCode()) {
 
     ...
     


### PR DESCRIPTION
There were a few other places where we missed renaming. I believe this is the end of it.

Signed-off-by: Robert Young <rwy0717@gmail.com>