### PR TITLE
Properly tag non integer constants as unsigned int

### DIFF
--- a/b9/include/b9/ExecutionContext.hpp
+++ b/b9/include/b9/ExecutionContext.hpp
@@ -78,17 +78,17 @@ class ExecutionContext {
 
   void doIntNot();
 
-  Immediate doIntJmpEq(Immediate delta);
+  Immediate doJmpEq(Immediate delta);
 
-  Immediate doIntJmpNeq(Immediate delta);
+  Immediate doJmpNeq(Immediate delta);
 
-  Immediate doIntJmpGt(Immediate delta);
+  Immediate doJmpGt(Immediate delta);
 
-  Immediate doIntJmpGe(Immediate delta);
+  Immediate doJmpGe(Immediate delta);
 
-  Immediate doIntJmpLt(Immediate delta);
+  Immediate doJmpLt(Immediate delta);
 
-  Immediate doIntJmpLe(Immediate delta);
+  Immediate doJmpLe(Immediate delta);
 
   void doStrPushConstant(Immediate value);
 

--- a/b9/include/b9/VirtualMachine.hpp
+++ b/b9/include/b9/VirtualMachine.hpp
@@ -126,7 +126,7 @@ extern "C" {
 using namespace b9;
 
 Om::RawValue interpret(ExecutionContext *context,
-                         const std::size_t functionIndex);
+                       const std::size_t functionIndex);
 
 void primitive_call(ExecutionContext *context, Immediate value);
 }

--- a/b9/include/b9/compiler/MethodBuilder.hpp
+++ b/b9/include/b9/compiler/MethodBuilder.hpp
@@ -53,7 +53,11 @@ class MethodBuilder : public TR::MethodBuilder {
 
   void pushInt48(TR::BytecodeBuilder *builder, TR::IlValue *value);
 
+  void pushUint48(TR::BytecodeBuilder *builder, TR::IlValue *value);
+
   TR::IlValue *popInt48(TR::BytecodeBuilder *builder);
+
+  TR::IlValue *popUint48(TR::BytecodeBuilder *builder);
 
   void drop(TR::BytecodeBuilder *builder, std::size_t n = 1);
 

--- a/b9/include/b9/instructions.hpp
+++ b/b9/include/b9/instructions.hpp
@@ -52,27 +52,23 @@ enum class OpCode : RawOpCode {
   INT_PUSH_CONSTANT = 0xf,
   // Invert a boolean value, all non-zero integers are true
   INT_NOT = 0x10,
-  // Jump if two integers are equal
-  INT_JMP_EQ = 0x11,
-  // Jump if two integer are not equal
-  INT_JMP_NEQ = 0x12,
-  // Jump if the first integer is greater than the second
-  INT_JMP_GT = 0x13,
-  // Jump if the first integer is greater than or equal to the second
-  INT_JMP_GE = 0x14,
-  // Jump if the first integer is less than to the second
-  INT_JMP_LT = 0x15,
-  // Jump if the first integer is less than or equal to the second
-  INT_JMP_LE = 0x16,
+  // Jump if two values are equal
+  JMP_EQ = 0x11,
+  // Jump if two values are not equal
+  JMP_NEQ = 0x12,
+  // Jump if the first value is greater than the second
+  JMP_GT = 0x13,
+  // Jump if the first value is greater than or equal to the second
+  JMP_GE = 0x14,
+  // Jump if the first value is less than to the second
+  JMP_LT = 0x15,
+  // Jump if the first value is less than or equal to the second
+  JMP_LE = 0x16,
 
   // String ByteCodes
 
   // Push a string from this module's constant pool
   STR_PUSH_CONSTANT = 0x17,
-  // Jump if two strings are equal
-  STR_JMP_EQ = 0x18,
-  // Jump if two strings are not equal
-  STR_JMP_NEQ = 0x19,
 
   // Object Bytecodes
 
@@ -123,24 +119,20 @@ inline const char *toString(OpCode bc) {
       return "int_push_constant";
     case OpCode::INT_NOT:
       return "int_not";
-    case OpCode::INT_JMP_EQ:
-      return "int_jmp_eq";
-    case OpCode::INT_JMP_NEQ:
-      return "int_jmp_neq";
-    case OpCode::INT_JMP_GT:
-      return "int_jmp_gt";
-    case OpCode::INT_JMP_GE:
-      return "int_jmp_ge";
-    case OpCode::INT_JMP_LT:
-      return "int_jmp_lt";
-    case OpCode::INT_JMP_LE:
-      return "int_jmp_le";
+    case OpCode::JMP_EQ:
+      return "jmp_eq";
+    case OpCode::JMP_NEQ:
+      return "jmp_neq";
+    case OpCode::JMP_GT:
+      return "jmp_gt";
+    case OpCode::JMP_GE:
+      return "jmp_ge";
+    case OpCode::JMP_LT:
+      return "jmp_lt";
+    case OpCode::JMP_LE:
+      return "jmp_le";
     case OpCode::STR_PUSH_CONSTANT:
       return "str_push_constant";
-    case OpCode::STR_JMP_EQ:
-      return "str_jmp_eq";
-    case OpCode::STR_JMP_NEQ:
-      return "str_jmp_neq";
     case OpCode::NEW_OBJECT:
       return "new_object";
     case OpCode::PUSH_FROM_OBJECT:
@@ -268,15 +260,13 @@ inline std::ostream &operator<<(std::ostream &out, Instruction i) {
     case OpCode::PUSH_FROM_PARAM:
     case OpCode::POP_INTO_PARAM:
     case OpCode::INT_PUSH_CONSTANT:
-    case OpCode::INT_JMP_EQ:
-    case OpCode::INT_JMP_NEQ:
-    case OpCode::INT_JMP_GT:
-    case OpCode::INT_JMP_GE:
-    case OpCode::INT_JMP_LT:
-    case OpCode::INT_JMP_LE:
+    case OpCode::JMP_EQ:
+    case OpCode::JMP_NEQ:
+    case OpCode::JMP_GT:
+    case OpCode::JMP_GE:
+    case OpCode::JMP_LT:
+    case OpCode::JMP_LE:
     case OpCode::STR_PUSH_CONSTANT:
-    case OpCode::STR_JMP_EQ:
-    case OpCode::STR_JMP_NEQ:
     case OpCode::PUSH_FROM_OBJECT:
     case OpCode::POP_INTO_OBJECT:
     default:

--- a/b9/src/MethodBuilder.cpp
+++ b/b9/src/MethodBuilder.cpp
@@ -350,27 +350,27 @@ bool MethodBuilder::generateILForBytecode(
       handle_bc_jmp(builder, bytecodeBuilderTable, program, instructionIndex,
                     nextBytecodeBuilder);
       break;
-    case OpCode::INT_JMP_EQ:
+    case OpCode::JMP_EQ:
       handle_bc_jmp_eq(builder, bytecodeBuilderTable, program, instructionIndex,
                        nextBytecodeBuilder);
       break;
-    case OpCode::INT_JMP_NEQ:
+    case OpCode::JMP_NEQ:
       handle_bc_jmp_neq(builder, bytecodeBuilderTable, program,
                         instructionIndex, nextBytecodeBuilder);
       break;
-    case OpCode::INT_JMP_LT:
+    case OpCode::JMP_LT:
       handle_bc_jmp_lt(builder, bytecodeBuilderTable, program, instructionIndex,
                        nextBytecodeBuilder);
       break;
-    case OpCode::INT_JMP_LE:
+    case OpCode::JMP_LE:
       handle_bc_jmp_le(builder, bytecodeBuilderTable, program, instructionIndex,
                        nextBytecodeBuilder);
       break;
-    case OpCode::INT_JMP_GT:
+    case OpCode::JMP_GT:
       handle_bc_jmp_gt(builder, bytecodeBuilderTable, program, instructionIndex,
                        nextBytecodeBuilder);
       break;
-    case OpCode::INT_JMP_GE:
+    case OpCode::JMP_GE:
       handle_bc_jmp_ge(builder, bytecodeBuilderTable, program, instructionIndex,
                        nextBytecodeBuilder);
       break;
@@ -399,7 +399,7 @@ bool MethodBuilder::generateILForBytecode(
     case OpCode::STR_PUSH_CONSTANT: {
       int index = instruction.immediate();
       /// TODO: Box/unbox here.
-      pushInt48(builder, builder->ConstInt64(index));
+      pushUint48(builder, builder->ConstInt64(index));
       if (nextBytecodeBuilder)
         builder->AddFallThroughBuilder(nextBytecodeBuilder);
     } break;
@@ -544,8 +544,8 @@ void MethodBuilder::handle_bc_jmp_neq(
   int next_bc_index = bytecodeIndex + delta;
   TR::BytecodeBuilder *jumpTo = bytecodeBuilderTable[next_bc_index];
 
-  TR::IlValue *right = popInt48(builder);
-  TR::IlValue *left = popInt48(builder);
+  TR::IlValue *right = popValue(builder);
+  TR::IlValue *left = popValue(builder);
 
   builder->IfCmpNotEqual(jumpTo, left, right);
   builder->AddFallThroughBuilder(nextBuilder);
@@ -561,8 +561,8 @@ void MethodBuilder::handle_bc_jmp_lt(
   int next_bc_index = bytecodeIndex + delta;
   TR::BytecodeBuilder *jumpTo = bytecodeBuilderTable[next_bc_index];
 
-  TR::IlValue *right = popInt48(builder);
-  TR::IlValue *left = popInt48(builder);
+  TR::IlValue *right = popValue(builder);
+  TR::IlValue *left = popValue(builder);
 
   builder->IfCmpLessThan(jumpTo, left, right);
   builder->AddFallThroughBuilder(nextBuilder);
@@ -689,6 +689,15 @@ void MethodBuilder::pushInt48(TR::BytecodeBuilder *builder,
 
 TR::IlValue *MethodBuilder::popInt48(TR::BytecodeBuilder *builder) {
   return OMR::Om::ValueBuilder::getInt48(builder, popValue(builder));
+}
+
+void MethodBuilder::pushUint48(TR::BytecodeBuilder *builder,
+                               TR::IlValue *value) {
+  pushValue(builder, OMR::Om::ValueBuilder::fromUint48(builder, value));
+}
+
+TR::IlValue *MethodBuilder::popUint48(TR::BytecodeBuilder *builder) {
+  return OMR::Om::ValueBuilder::getUint48(builder, popValue(builder));
 }
 
 }  // namespace b9

--- a/b9/src/VirtualMachine.cpp
+++ b/b9/src/VirtualMachine.cpp
@@ -152,7 +152,7 @@ StackElement VirtualMachine::run(const std::size_t functionIndex,
 extern "C" {
 
 Om::RawValue interpret(ExecutionContext *context,
-                     const std::size_t functionIndex) {
+                       const std::size_t functionIndex) {
   return (Om::RawValue)context->interpret(functionIndex);
 }
 

--- a/b9/src/primitives.cpp
+++ b/b9/src/primitives.cpp
@@ -15,8 +15,8 @@ extern "C" void b9_prim_print_number(ExecutionContext *context) {
 /// ( string -- 0 )
 extern "C" void b9_prim_print_string(ExecutionContext *context) {
   auto value = context->pop();
-  assert(value.isInt48());
-  auto string = context->virtualMachine()->getString(value.getInt48());
+  assert(value.isUint48());
+  auto string = context->virtualMachine()->getString(value.getUint48());
   std::cout << string << std::endl;
   context->push({Om::AS_INT48, 0});
 }

--- a/docs/build-a-runtime/index.md
+++ b/docs/build-a-runtime/index.md
@@ -432,7 +432,7 @@ The fields of the `FunctionDef` are the function name, the index in the function
 
 ### The base9 Instruction Set
 
-The base9 VM executes it’s own instruction set. The instructions are compiled from the frontend language. Each instruction is a 32-bit little-endian value, which encodes an opcode (AKA a bytecode), and an optional immediate. The opcode is the most significant byte of the instruction. It tells the VM which functionality to execute. The opcode is one of the special predefined constants that the VM understands. Example opcodes are `int_add`, `int_sub`, `int_jmp_eq`, and `function_return`. Each opcode corresponds with a unique hexadecimal value between 0 and n, where n is the total number of bytecodes.
+The base9 VM executes it’s own instruction set. The instructions are compiled from the frontend language. Each instruction is a 32-bit little-endian value, which encodes an opcode (AKA a bytecode), and an optional immediate. The opcode is the most significant byte of the instruction. It tells the VM which functionality to execute. The opcode is one of the special predefined constants that the VM understands. Example opcodes are `int_add`, `int_sub`, `jmp_eq`, and `function_return`. Each opcode corresponds with a unique hexadecimal value between 0 and n, where n is the total number of bytecodes.
 
 The immediate encodes the constant data about an instruction. For example, a jump instruction encodes it’s jump target in the immediate. The immediate is a signed value stored in the lower 24 bits of the instruction.
 

--- a/docs/docs/B9Assembly.md
+++ b/docs/docs/B9Assembly.md
@@ -10,7 +10,7 @@ section: docs
 (function "factorial" 1 0
   0  (push_from_var 0)
   1  (int_push_constant 0)
-  2  (int_jmp_neq 2)
+  2  (jmp_neq 2)
   3  (int_push_constant 1)
   4  (function_return)
   5  (push_from_var 0)

--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -42,36 +42,34 @@ var OperatorCode = Object.freeze({
 	"INT_DIV": 14,
 	"INT_PUSH_CONSTANT": 15,
 	"INT_NOT": 16,
-	"INT_JMP_EQ": 17,
-	"INT_JMP_NEQ": 18,
-	"INT_JMP_GT": 19,
-	"INT_JMP_GE": 20,
-	"INT_JMP_LT": 21,
-	"INT_JMP_LE": 22,
+	"JMP_EQ": 17,
+	"JMP_NEQ": 18,
+	"JMP_GT": 19,
+	"JMP_GE": 20,
+	"JMP_LT": 21,
+	"JMP_LE": 22,
 	"STR_PUSH_CONSTANT": 23,
-	"STR_JMP_EQ": 24,
-	"STR_JMP_NEQ": 25
 });
 
 /// Binary comparison operators converted to jump instructions
 JumpOperator = Object.freeze({
-	"==": "INT_JMP_EQ",
-	"!=": "INT_JMP_NEQ",
-	"<=": "INT_JMP_LE",
-	">=": "INT_JMP_GE",
-	"<": "INT_JMP_LT",
-	">": "INT_JMP_GT"
+	"==": "JMP_EQ",
+	"!=": "JMP_NEQ",
+	"<=": "JMP_LE",
+	">=": "JMP_GE",
+	"<": "JMP_LT",
+	">": "JMP_GT"
 });
 
 /// Map binary comparison operators to jump instructions that invert the condition.
 /// as an example, the if statement handler will use this table to invert a comparison, and jump over the if-true block.
 var NegJumpOperator = Object.freeze({
-	"==": "INT_JMP_NEQ",
-	"!=": "INT_JMP_EQ",
-	"<=": "INT_JMP_GT",
-	">=": "INT_JMP_LT",
-	"<": "INT_JMP_GE",
-	">": "INT_JMP_LE"
+	"==": "JMP_NEQ",
+	"!=": "JMP_EQ",
+	"<=": "JMP_GT",
+	">=": "JMP_LT",
+	"<": "JMP_GE",
+	">": "JMP_LE"
 });
 
 /// Map a++ style operators to b9 operator codes.
@@ -254,12 +252,12 @@ function FunctionDefinition(outer, name) {
 			var instruction = this.instructions[index];
 			switch (instruction.operator) {
 				case "JMP":
-				case "INT_JMP_EQ":
-				case "INT_JMP_NEQ":
-				case "INT_JMP_GT":
-				case "INT_JMP_GE":
-				case "INT_JMP_LT":
-				case "INT_JMP_LE":
+				case "JMP_EQ":
+				case "JMP_NEQ":
+				case "JMP_GT":
+				case "JMP_GE":
+				case "JMP_LT":
+				case "JMP_LE":
 					// the label id is stuffed in the operand.
 					// translate the label to a relative offset.
 					instruction.operand = this.resolveLabel(instruction.operand, index);
@@ -797,7 +795,7 @@ function FirstPassCodeGen() {
 	this.handleIfStatement = function (func, statement) {
 		var alternateLabel = func.labels.create();
 		var endLabel = func.labels.create();
-		comparator = this.emitTest(func, statement.test);
+		var comparator = this.emitTest(func, statement.test);
 		if (statement.alternate) {
 			func.instructions.push(new Instruction(NegJumpOperator[comparator], alternateLabel));
 		} else {

--- a/test/b9test.cpp
+++ b/test/b9test.cpp
@@ -37,7 +37,6 @@ const std::vector<const char*> TEST_NAMES = {
   "test_lessThanOrEqual_1",
   "test_call",
   "test_string_declare_string_var",
-  "helper_test_string_return_string",
   "test_string_return_string",
   "test_while",
   "test_for_never_run_body",

--- a/test/interpreter_test.js
+++ b/test/interpreter_test.js
@@ -222,7 +222,7 @@ function helper_test_string_return_string() {
 
 function test_string_return_string() {
     var a = helper_test_string_return_string();
-    if (a != 0) {
+    if (a == "Hi") {
         return 1;
     }
     return 0;


### PR DESCRIPTION
Changes include:

 * Interpreter pushes string into stack as OM::Value of uint48 kind
 * INT_JMP bytecodes made into generic non type-specific JMP bytecodes
 * New methods in MethodBuilder: push/popUint48() meant to handle
   strings
 * b9_prim_print_string now expects a uint48 value for string index
 * Fixed a potential bug in the frontend where the variable comparator
   was being declared as global variable due to missing var keyword
 * Removed a helper method in the interpreter test that returns a
   string literal
 * Ran clang-format
 * Updated b9 assembly example with the new equivalent jmp operator

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>