### PR TITLE
Fix targets for b9 modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,15 +80,22 @@ set(OMR_WARNINGS_AS_ERRORS OFF CACHE INTERNAL "OMR doesn't compile cleanly on my
 
 # Compile a b9-js *.js to C++
 function(add_b9_module src)
-	add_custom_target(compile_${src} ALL
+	add_custom_command(
+		OUTPUT
+			"${CMAKE_CURRENT_BINARY_DIR}/${src}.b9mod"
 		COMMAND
 			${NODE_EXECUTABLE}
 			"${CMAKE_SOURCE_DIR}/js_compiler/compile.js"
 			"${CMAKE_CURRENT_SOURCE_DIR}/${src}.js"
 			"${src}.b9mod"
-		DEPENDS
+		MAIN_DEPENDENCY
 			"${CMAKE_CURRENT_SOURCE_DIR}/${src}.js"
+		DEPENDS
 			"${CMAKE_SOURCE_DIR}/js_compiler/compile.js"
+	)
+	add_custom_target(compile_${src} ALL
+		DEPENDS
+			"${CMAKE_CURRENT_BINARY_DIR}/${src}.b9mod"
 	)
 endfunction(add_b9_module)
 


### PR DESCRIPTION
custom targets are always considered out of date, thus the old b9
modules will always be recompiled. Move to using add_custom_command
which properly tracks dependency, and wrap that with a custom target

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>