### PR TITLE
Update js_compiler for older versions of nodejs

### DIFF
--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -7,6 +7,13 @@ CONVERT B9 PORCELAIN TO BINARY MODULE
 var esprima = require('esprima');
 var fs = require('fs');
 
+// Support for old versions of node, which don't have Buffer.alloc
+if (!Buffer.alloc) {
+    Buffer.alloc = function(sz) {
+        return new Buffer(sz);
+    }
+}
+
 function outputUInt32(out, value) {
 	var buf = Buffer.alloc(4);
 	buf.writeUInt32LE(value, 0);


### PR DESCRIPTION
Older versions of nodejs dont have the Buffer.alloc() method. If this
method is not found this change will provide a fallback implementation

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>