### PR TITLE
update SymboTable map to not inherit properties

### DIFF
--- a/js_compiler/compile.js
+++ b/js_compiler/compile.js
@@ -104,8 +104,8 @@ var Instruction = function (operator, operand) {
 
 var SymbolTable = function () {
 
-	this.next = 0;
-	this.map = {};
+	this.next = 0; 
+	this.map = Object.create(null);  
 
 	/// Look up a symbol without interning.
 	this.lookup = function (symbol) {


### PR DESCRIPTION
Variables that map to Object properties are no longer "pre-defined".

Signed-off-by: John Duimovich <jduimovich@gmail.com>